### PR TITLE
Support Omnipay ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         }
     },
     "require": {
-        "omnipay/common": "^2.0|^3.0"
+        "omnipay/common": "^3.0"
     },
     "require-dev": {
-        "omnipay/tests": "^2.0|^3.0",
+        "omnipay/tests": "^3.0",
         "squizlabs/php_codesniffer": "~1.5"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "^2.0|^3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0",
+        "omnipay/tests": "^2.0|^3.0",
         "squizlabs/php_codesniffer": "~1.5"
     },
     "extra": {

--- a/src/Common/SignatureValidator.php
+++ b/src/Common/SignatureValidator.php
@@ -8,7 +8,7 @@
 
 namespace Omnipay\Paysera\Common;
 
-use Guzzle\Http\ClientInterface;
+use GuzzleHttp\ClientInterface;
 
 /**
  * Class SignatureValidator
@@ -51,7 +51,7 @@ class SignatureValidator
      */
     private static function isValidSS2(array $data, ClientInterface $client)
     {
-        $response = $client->get(self::ENDPOINT)->send();
+        $response = $client->request('GET', self::ENDPOINT);
         if (200 === $response->getStatusCode() && false !== $publicKey = openssl_get_publickey($response->getBody())) {
             return 1 === openssl_verify($data['data'], Encoder::decode($data['ss2']), $publicKey);
         }


### PR DESCRIPTION
This PR adds compatibility with Omnipay ^3.0 and drops support of Omnipay ~2.0.

Because of Omnipay 3 is using Guzzle Http ^6.0 now, I made some changes in `SignatureValidator` class to achieve compatibility.

@povils if you'll approve and merge this PR, please tag a new version `v2.0.0` of package, because this PR contains breaking changes.